### PR TITLE
Require activity in iteration 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ For the `breakout` method, the key is a person's name and the value is what they
 pry(main)> require './lib/reunion'
 # => true
 
+pry(main)> require './lib/activity'
+# => true
+
 pry(main)> reunion = Reunion.new("1406 BE")
 # => #<Reunion:0x007fe4ca1defc8 ...>
 

--- a/lib/activity.rb
+++ b/lib/activity.rb
@@ -1,0 +1,27 @@
+class Activity
+  attr_reader :name, :participants
+  def initialize(name)
+    @name = name
+    @participants = Hash.new(0)
+  end
+
+  def add_participant(name, cost)
+    @participants[name] += cost
+  end
+
+  def total_cost
+    @participants.values.sum
+  end
+
+  def split
+    total_cost / @participants.keys.count
+  end
+
+  def owed
+    owed_hash = Hash.new { |hash, key| hash[key] = 0 }
+    @participants.each do |participant, cost|
+      owed_hash[participant] = split - cost
+    end
+    owed_hash
+  end
+end

--- a/lib/reunion.rb
+++ b/lib/reunion.rb
@@ -1,0 +1,57 @@
+class Reunion
+  attr_reader :name, :activities
+  def initialize(name)
+    @name = name
+    @activities = []
+  end
+
+  def add_activity(activity)
+    @activities << activity
+  end
+
+  def total_cost
+    reunion_cost = @activities.sum do |activity|
+      activity.total_cost
+    end
+    reunion_cost
+  end
+
+  # def breakout
+  #   total_owed = Hash.new { |hash, key| hash[key] = 0 }
+  #   @activities.each do |activity|
+  #     require "pry"; binding.pry
+  #     activity.owed
+  #   end
+  #   total_owed
+  # end
+
+  def participant_count
+    total_participants = []
+    @activities.sort_by do |activity|
+      total_participants << activity.participants.keys
+    end
+    total_participants.flatten.uniq.count
+  end
+
+  def cost_per_participant
+    total_cost / participant_count
+  end
+
+  def breakout
+    breakout_hash = Hash.new { |hash, key| hash[key] = 0 }
+    @activities.each do |activity|
+      activity.participants.each do |participant, cost|
+        breakout_hash[participant] += activity.split - cost
+      end
+    end
+    breakout_hash
+  end
+
+  def summary
+    breakout_summary = []
+    breakout.each do |name, cost|
+      breakout_summary << name + ": " + "#{cost}\n"
+    end
+    breakout_summary.join.chomp
+  end
+end

--- a/test/activity_test.rb
+++ b/test/activity_test.rb
@@ -1,0 +1,47 @@
+require 'minitest/autorun'
+require 'minitest/pride'
+require './lib/activity'
+class ActivityTest < Minitest::Test
+
+  def setup
+    @activity = Activity.new("Brunch")
+  end
+
+  def test_it_exists_and_has_attributes
+    assert_instance_of Activity, @activity
+    assert_equal "Brunch", @activity.name
+    assert_equal ({}), @activity.participants
+  end
+
+  def test_add_participant
+    @activity.add_participant("Maria", 20)
+
+    expected = {"Maria" => 20}
+
+    assert_equal expected, @activity.participants
+  end
+
+  def test_total_cost
+    @activity.add_participant("Maria", 20)
+
+    assert_equal 20, @activity.total_cost
+
+    @activity.add_participant("Luther", 40)
+
+    expected = {"Maria" => 20, "Luther" => 40}
+
+    assert_equal expected, @activity.participants
+    assert_equal 60, @activity.total_cost
+  end
+
+  def test_split_and_owed
+    @activity.add_participant("Maria", 20)
+    @activity.add_participant("Luther", 40)
+
+    assert_equal 30, @activity.split
+
+    expected = {"Maria" => 10, "Luther" => -10}
+
+    assert_equal expected, @activity.owed
+  end
+end

--- a/test/reunion_test.rb
+++ b/test/reunion_test.rb
@@ -1,0 +1,51 @@
+require 'minitest/autorun'
+require 'minitest/pride'
+require './lib/reunion'
+require './lib/activity'
+
+class ReunionTest < Minitest::Test
+
+  def setup
+    @reunion = Reunion.new("1406 BE")
+    @activity_1 = Activity.new("Brunch")
+    @activity_2 = Activity.new("Drinks")
+  end
+
+  def test_it_exists_and_has_attributes
+    assert_instance_of Reunion, @reunion
+    assert_equal "1406 BE", @reunion.name
+  end
+
+  def test_add_activities
+    assert_equal [], @reunion.activities
+
+    @reunion.add_activity(@activity_1)
+
+    assert_equal [@activity_1], @reunion.activities
+  end
+
+  def test_case_name
+    @activity_1.add_participant("Maria", 20)
+    @activity_1.add_participant("Luther", 40)
+    @reunion.add_activity(@activity_1)
+
+    assert_equal 60, @reunion.total_cost
+
+    @activity_2.add_participant("Maria", 60)
+    @activity_2.add_participant("Luther", 60)
+    @activity_2.add_participant("Louis", 0)
+    @reunion.add_activity(@activity_2)
+
+    assert_equal 180, @reunion.total_cost
+
+    expected = {"Maria" => -10, "Luther" => -30, "Louis" => 40}
+
+    assert_equal 3, @reunion.participant_count
+    assert_equal 60, @reunion.cost_per_participant
+    assert_equal expected, @reunion.breakout
+
+    expected = ("Maria: -10\nLuther: -30\nLouis: 40")
+
+    assert_equal expected, @reunion.summary
+  end
+end


### PR DESCRIPTION
I ended up needing to require the below in interaction pattern for iteration 3. My apologies if it's absence was intentional!

```ruby
pry(main)> require './lib/activity'
# => true
```